### PR TITLE
Fix: schedule updates only touch selected days

### DIFF
--- a/Sleepypod/Networking/FreeSleepClient.swift
+++ b/Sleepypod/Networking/FreeSleepClient.swift
@@ -44,7 +44,7 @@ final class FreeSleepClient: SleepypodProtocol, @unchecked Sendable {
         try await get(.schedules)
     }
 
-    func updateSchedules(_ schedules: Schedules) async throws -> Schedules {
+    func updateSchedules(_ schedules: Schedules, days: Set<DayOfWeek>? = nil) async throws -> Schedules {
         try await post(.updateSchedules, body: schedules)
     }
 

--- a/Sleepypod/Networking/SleepypodCoreClient.swift
+++ b/Sleepypod/Networking/SleepypodCoreClient.swift
@@ -143,13 +143,14 @@ final class SleepypodCoreClient: SleepypodProtocol, @unchecked Sendable {
         )
     }
 
-    func updateSchedules(_ schedules: Schedules) async throws -> Schedules {
-        // Only update days that have data — don't touch other days
+    func updateSchedules(_ schedules: Schedules, days: Set<DayOfWeek>? = nil) async throws -> Schedules {
+        let daysToUpdate = days ?? Set(DayOfWeek.allCases)
+
         for side in [Side.left, .right] {
             let existing: TRPCScheduleSet = try await query("schedules.getAll", input: ["side": side.rawValue])
             let sideSchedule = schedules.schedule(for: side)
 
-            for day in DayOfWeek.allCases {
+            for day in daysToUpdate {
                 let daily = sideSchedule[day]
                 let hasData = !daily.temperatures.isEmpty || daily.power.enabled || daily.alarm.enabled
 

--- a/Sleepypod/Networking/SleepypodProtocol.swift
+++ b/Sleepypod/Networking/SleepypodProtocol.swift
@@ -6,7 +6,7 @@ protocol SleepypodProtocol: Sendable {
     func getSettings() async throws -> PodSettings
     func updateSettings(_ settings: PodSettings) async throws -> PodSettings
     func getSchedules() async throws -> Schedules
-    func updateSchedules(_ schedules: Schedules) async throws -> Schedules
+    func updateSchedules(_ schedules: Schedules, days: Set<DayOfWeek>?) async throws -> Schedules
     func getServerStatus() async throws -> ServerStatus
     func getServices() async throws -> Services
     func updateServices(_ services: Services) async throws -> Services

--- a/Sleepypod/Services/ScheduleManager.swift
+++ b/Sleepypod/Services/ScheduleManager.swift
@@ -77,7 +77,7 @@ final class ScheduleManager {
         self.schedules = schedules
 
         do {
-            self.schedules = try await api.updateSchedules(schedules)
+            self.schedules = try await api.updateSchedules(schedules, days: [selectedDay])
         } catch {
             self.error = error.localizedDescription
             await fetchSchedules()
@@ -107,7 +107,7 @@ final class ScheduleManager {
 
         self.schedules = schedules
         do {
-            self.schedules = try await api.updateSchedules(schedules)
+            self.schedules = try await api.updateSchedules(schedules, days: [selectedDay])
         } catch {
             self.error = error.localizedDescription
             await fetchSchedules()
@@ -137,7 +137,7 @@ final class ScheduleManager {
 
         self.schedules = schedules
         do {
-            self.schedules = try await api.updateSchedules(schedules)
+            self.schedules = try await api.updateSchedules(schedules, days: [selectedDay])
         } catch {
             self.error = error.localizedDescription
             await fetchSchedules()
@@ -170,7 +170,7 @@ final class ScheduleManager {
         self.schedules = schedules
 
         do {
-            self.schedules = try await api.updateSchedules(schedules)
+            self.schedules = try await api.updateSchedules(schedules, days: [selectedDay])
         } catch {
             self.error = error.localizedDescription
             await fetchSchedules()
@@ -197,7 +197,7 @@ final class ScheduleManager {
         self.schedules = schedules
 
         do {
-            self.schedules = try await api.updateSchedules(schedules)
+            self.schedules = try await api.updateSchedules(schedules, days: [selectedDay])
         } catch {
             self.error = error.localizedDescription
             await fetchSchedules()

--- a/Sleepypod/Views/Schedule/ScheduleScreen.swift
+++ b/Sleepypod/Views/Schedule/ScheduleScreen.swift
@@ -114,7 +114,7 @@ struct ScheduleScreen: View {
         scheduleManager.schedules = schedules
         do {
             let api = APIBackend.current.createClient()
-            scheduleManager.schedules = try await api.updateSchedules(schedules)
+            scheduleManager.schedules = try await api.updateSchedules(schedules, days: scheduleManager.selectedDays)
             Haptics.heavy()
         } catch {
             scheduleManager.schedules = previous

--- a/Sleepypod/Views/Schedule/SmartCurveView.swift
+++ b/Sleepypod/Views/Schedule/SmartCurveView.swift
@@ -604,7 +604,7 @@ struct SmartCurveView: View {
             scheduleManager.schedules = schedules
             do {
                 let api = APIBackend.current.createClient()
-                scheduleManager.schedules = try await api.updateSchedules(schedules)
+                scheduleManager.schedules = try await api.updateSchedules(schedules, days: scheduleManager.selectedDays)
             } catch {
                 Log.general.error("Failed to save smart curve: \(error)")
             }

--- a/SleepypodTests/MockAPIClient.swift
+++ b/SleepypodTests/MockAPIClient.swift
@@ -17,7 +17,7 @@ class MockAPIClient: SleepypodProtocol, @unchecked Sendable {
     func getSettings() async throws -> PodSettings { throw APIError.noBaseURL }
     func updateSettings(_ settings: PodSettings) async throws -> PodSettings { throw APIError.noBaseURL }
     func getSchedules() async throws -> Schedules { throw APIError.noBaseURL }
-    func updateSchedules(_ schedules: Schedules) async throws -> Schedules { throw APIError.noBaseURL }
+    func updateSchedules(_ schedules: Schedules, days: Set<DayOfWeek>? = nil) async throws -> Schedules { throw APIError.noBaseURL }
     func getServerStatus() async throws -> ServerStatus { throw APIError.noBaseURL }
     func getServices() async throws -> Services { throw APIError.noBaseURL }
     func updateServices(_ services: Services) async throws -> Services { throw APIError.noBaseURL }


### PR DESCRIPTION
## Summary

Selecting Monday and applying a schedule was modifying all 7 days. Now only the selected days are updated.

## Root cause

`updateSchedules` iterated `DayOfWeek.allCases` regardless of which days the caller actually modified. A Monday-only edit would delete and recreate entries for every day of the week.

## Fix

Added `days: Set<DayOfWeek>?` parameter to `updateSchedules`. All callers now pass their specific days:

| Caller | Days passed |
|---|---|
| SmartCurveView (apply curve) | `scheduleManager.selectedDays` (multi-select) |
| ScheduleScreen (clear) | `scheduleManager.selectedDays` (multi-select) |
| ScheduleManager (single-day edits) | `[selectedDay]` |

When `days` is `nil` (default), all days are updated (backward compatible).

## Test plan
- [ ] Select Monday only, apply smart curve → verify Tuesday–Sunday untouched
- [ ] Select Mon+Tue, apply curve → verify only those 2 days updated
- [ ] Clear schedule for Wednesday → verify other days preserved
- [ ] Edit single phase temperature → verify only that day changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Improvements
- Schedule updates now support day-specific modifications. Apply changes to selected days only rather than updating all days simultaneously
- Users gain enhanced control when updating temperature, power, alarm, and bedtime schedules with flexible day selection options
- Improved schedule management with more granular, day-based customization capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->