### PR TITLE
Fix bundle identifier

### DIFF
--- a/Sleepypod/Services/Log.swift
+++ b/Sleepypod/Services/Log.swift
@@ -2,11 +2,11 @@ import OSLog
 
 /// Centralized loggers for the app. Logs persist on device and can be pulled via:
 ///   log collect --device --start "2026-03-15" --output sleepypod.logarchive
-///   log show sleepypod.logarchive --predicate 'subsystem == "com.sleepypod.ios"'
+///   log show sleepypod.logarchive --predicate 'subsystem == "com.jonathanng.ios.sleepypod"'
 enum Log {
-    static let network = Logger(subsystem: "com.sleepypod.ios", category: "network")
-    static let discovery = Logger(subsystem: "com.sleepypod.ios", category: "discovery")
-    static let device = Logger(subsystem: "com.sleepypod.ios", category: "device")
-    static let general = Logger(subsystem: "com.sleepypod.ios", category: "general")
-    static let sensor = Logger(subsystem: "com.sleepypod.ios", category: "sensor")
+    static let network = Logger(subsystem: "com.jonathanng.ios.sleepypod", category: "network")
+    static let discovery = Logger(subsystem: "com.jonathanng.ios.sleepypod", category: "discovery")
+    static let device = Logger(subsystem: "com.jonathanng.ios.sleepypod", category: "device")
+    static let general = Logger(subsystem: "com.jonathanng.ios.sleepypod", category: "general")
+    static let sensor = Logger(subsystem: "com.jonathanng.ios.sleepypod", category: "sensor")
 }

--- a/project.yml
+++ b/project.yml
@@ -1,6 +1,6 @@
 name: Sleepypod
 options:
-  bundleIdPrefix: com.sleepypod
+  bundleIdPrefix: com.jonathanng.ios.sleepypod
   deploymentTarget:
     iOS: "26.0"
   xcodeVersion: "26"
@@ -33,7 +33,7 @@ targets:
           - health-records
     settings:
       base:
-        PRODUCT_BUNDLE_IDENTIFIER: com.sleepypod.ios
+        PRODUCT_BUNDLE_IDENTIFIER: com.jonathanng.ios.sleepypod
         INFOPLIST_FILE: Sleepypod/Info.plist
         INFOPLIST_KEY_NSHealthShareUsageDescription: "Sleepypod uses your sleep schedule to automatically set bedtime and wake temperatures"
         INFOPLIST_KEY_UIApplicationSceneManifest_Generation: true
@@ -54,4 +54,4 @@ targets:
       - target: Sleepypod
     settings:
       base:
-        PRODUCT_BUNDLE_IDENTIFIER: com.sleepypod.ios.tests
+        PRODUCT_BUNDLE_IDENTIFIER: com.jonathanng.ios.sleepypod.tests


### PR DESCRIPTION
## Summary
- Update bundle ID from `com.sleepypod.ios` to `com.jonathanng.ios.sleepypod`
- Update test bundle ID to `com.jonathanng.ios.sleepypod.tests`
- Update Logger subsystem references in Log.swift

## Test plan
- [x] xcodegen generates successfully
- [ ] Build and install on device to verify signing

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated app bundle identifiers and logging subsystem configuration to align with new naming conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->