### PR TITLE
ci: upload Swift test coverage to Codecov

### DIFF
--- a/.github/workflows/contract-test.yml
+++ b/.github/workflows/contract-test.yml
@@ -99,7 +99,33 @@ jobs:
         run: bash contract-tests/scripts/snapshot-responses.sh
 
       - name: Run Swift contract tests
-        run: cd contract-tests && swift test
+        run: cd contract-tests && swift test --enable-code-coverage
+
+      - name: Export coverage to lcov
+        if: always()
+        run: |
+          cd contract-tests
+          BIN_PATH=$(swift build --show-bin-path)
+          PROFDATA="$BIN_PATH/codecov/default.profdata"
+          XCTEST_BIN=$(find "$BIN_PATH" -name '*.xctest' -print -quit)
+          BINARY="$XCTEST_BIN/Contents/MacOS/$(basename "$XCTEST_BIN" .xctest)"
+          if [ -f "$PROFDATA" ] && [ -f "$BINARY" ]; then
+            xcrun llvm-cov export -format=lcov \
+              -instr-profile "$PROFDATA" \
+              "$BINARY" > lcov.info
+          else
+            echo "::warning::profdata or xctest binary missing — skipping lcov export"
+            : > lcov.info
+          fi
+
+      - name: Upload coverage reports to Codecov
+        if: always()
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: sleepypod/ios
+          files: contract-tests/lcov.info
+          flags: contract-tests
 
       - name: Stop server
         if: always()

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Sleepypod iOS
 
+[![codecov](https://codecov.io/gh/sleepypod/ios/branch/dev/graph/badge.svg)](https://codecov.io/gh/sleepypod/ios)
+
 Native iOS app for controlling and monitoring your [Sleepypod](https://github.com/sleepypod/core) — temperature control, sleep tracking, biometrics, and on-device analysis.
 
 <p align="center">


### PR DESCRIPTION
## Summary
- Adds `--enable-code-coverage` to `swift test` in the contract-test job
- Exports the resulting `default.profdata` to `lcov.info` via `xcrun llvm-cov export -format=lcov`
- Uploads via `codecov/codecov-action@v5` with `flags: contract-tests`
- Adds README badge

Coverage is generated only by the contract-tests SPM package today (Sleepypod.xcodeproj scheme has no test target wired into CI). When iOS unit tests land, add a parallel job and a second upload with a different `flags:` value.

## Test plan
- [ ] Open this PR → green CI
- [ ] Confirm the `Export coverage to lcov` step finds `default.profdata` and emits non-empty `contract-tests/lcov.info`
- [ ] Confirm Codecov receives the upload (codecov.io/gh/sleepypod/ios)
- [ ] Add `CODECOV_TOKEN` secret to repo before merge — `gh secret set CODECOV_TOKEN -R sleepypod/ios`