### PR TITLE
feat: write sleep + vitals to Apple HealthKit

### DIFF
--- a/Sleepypod.xcodeproj/project.pbxproj
+++ b/Sleepypod.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 63;
+	objectVersion = 77;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -11,8 +11,6 @@
 		041D6F2AA0D299253FFA1B27 /* Services.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D8F3BFDBBA72B77A16C8606 /* Services.swift */; };
 		0888B106CC86FB2F3C652F8D /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = B7ADF7C27937207223FDBAD9 /* PrivacyInfo.xcprivacy */; };
 		0911824544AF401433A9DC43 /* PiezoWaveformView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BC90983ABD4505D2BE197D8 /* PiezoWaveformView.swift */; };
-		BEDTEMPTV002BEDTEMPTV002 /* BedTempTrendView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEDTEMPTV001BEDTEMPTV001 /* BedTempTrendView.swift */; };
-		RUNONCEBANNER02RUNONCE /* RunOnceActiveBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = RUNONCEBANNER01RUNONCE /* RunOnceActiveBanner.swift */; };
 		0B484FB88EA2286B4B2B83EB /* ScheduleScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00032A1688C27E11B0BF64CC /* ScheduleScreen.swift */; };
 		1201459B0B50A7E1250D248B /* openapi.json in Resources */ = {isa = PBXBuildFile; fileRef = B881147C7D2F0ADEBAD1AD02 /* openapi.json */; };
 		1558A064C84FC3F65897D129 /* TemperatureConversion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30D386CF79858C76A30F9B9E /* TemperatureConversion.swift */; };
@@ -40,6 +38,7 @@
 		59D63C6FB621C08C2D068AA7 /* NotificationRelay.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3B44F02B272682A83840CA4 /* NotificationRelay.swift */; };
 		5D6566441668D7E70CE84F29 /* FreeSleepClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 970CD9734D4BC3ACBE225328 /* FreeSleepClient.swift */; };
 		5F58632442748EC2A7862CB1 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9E902CB9201C2AE527A6C49F /* Assets.xcassets */; };
+		6363D9DF1E8F01CF5B5D7B88 /* SanitizeIPTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E3176EB2A6FF2F190D09EC5 /* SanitizeIPTests.swift */; };
 		650EC4F1527BA82FBF187755 /* SettingsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68BEE347AC8D43152FFBEE7B /* SettingsManager.swift */; };
 		67DB457E3E2AF5AE9DCB628F /* UserProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = B89A040B405BEF4117A8324F /* UserProfile.swift */; };
 		6C2843125C47D323DAB695BC /* APIBackend.swift in Sources */ = {isa = PBXBuildFile; fileRef = 295C867DF528905A55668F52 /* APIBackend.swift */; };
@@ -56,12 +55,14 @@
 		80473DBF0C206E692C09E07B /* StatusManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F4EAF0885B4206D02501DC8 /* StatusManager.swift */; };
 		8267672B7C3A060FF4D8AB52 /* HealthMetricsGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04710A8ABCD6BE865AA7E37E /* HealthMetricsGridView.swift */; };
 		874862C240D71E13B2FE3722 /* PiezoAnalyzer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4464A41F150702F0C25D231 /* PiezoAnalyzer.swift */; };
+		89AD7DED764ACC27468103F0 /* BedTempTrendView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB9D4912797C4F2688E60E8A /* BedTempTrendView.swift */; };
 		89CC786871A5B3B08D0EC3C4 /* Schedule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E2FC5FEF1954A73556633CF /* Schedule.swift */; };
 		8DD9CBBCA55884DBA45F5938 /* MetricsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7A651EEB721EF0EFD1B2D16 /* MetricsManager.swift */; };
 		8DDF8FDD9FE7688543CA8831 /* APIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = A42ACA637081CABD4502D011 /* APIError.swift */; };
 		8FE251F5B081255681839A64 /* ShareSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = A22017869B6697F13244EF76 /* ShareSheet.swift */; };
 		910535B30A8B5FBB4DE1B33C /* SleepTimeCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FCC5EA8D41BF91BCCFDEA6D /* SleepTimeCardView.swift */; };
 		9134DC5F465DB3F287914037 /* HealthCircleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3AB3B17FD36D878C2457E20 /* HealthCircleView.swift */; };
+		92B1607F8D33BC281B15AAAE /* RunOnceActiveBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20D1974B2E3BAF1AB09CDAB /* RunOnceActiveBanner.swift */; };
 		973184378E3DE691E858EC2E /* DaySelectorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9FF9D7BA24408A31A5A650C /* DaySelectorView.swift */; };
 		9D7F9E63ABF049359432DF0F /* DeviceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2941CA088FC1C77B69F36D60 /* DeviceManager.swift */; };
 		A0711D54FE9EF5E664D13E9C /* SleepypodCoreClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87060AD52798647A518FA8BE /* SleepypodCoreClient.swift */; };
@@ -79,9 +80,9 @@
 		BA94451123ED98F30EAC7AF8 /* Side.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB85BC15DC6D3030C728B6FC /* Side.swift */; };
 		BC37EEEE2AD3A4072D8141B0 /* InternetToggleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC70CD7C5F0C026275B7EFF6 /* InternetToggleTests.swift */; };
 		BFB6082091FA1466BC8B228A /* WeeklyBarChartView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6A21CD5C2B8905CF28D262D /* WeeklyBarChartView.swift */; };
-		C0264F041E3EDCEB719883ED /* SanitizeIPTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EBFFAA5F176842190082A2F /* SanitizeIPTests.swift */; };
 		C4D7F73C779F1ED2B685A770 /* DataPipelineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C23ED1E696702811954A0DA /* DataPipelineView.swift */; };
 		C92D44C303EF1CBE9D6B8F3A /* SmartCurveView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 883B7737894F367125F721FF /* SmartCurveView.swift */; };
+		CA2789A9258049A574B585A8 /* HealthKitManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5D57FD90897EC6A2B58ABF3 /* HealthKitManager.swift */; };
 		CD014B9CEE2C262CDD2637B5 /* SleepAnalyzerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE5C25057170EC9CC2049440 /* SleepAnalyzerTests.swift */; };
 		D45FD73FE3DE25E49C9FAD2D /* PrimingIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E5DFA72720A6968DE3369C /* PrimingIndicator.swift */; };
 		D5D9989913D7AC299A9531E4 /* SleepProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A89CDBBC9BF2AAE10BA0302 /* SleepProfile.swift */; };
@@ -130,11 +131,11 @@
 		2D039BE0CE64C5F6438E6442 /* LoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingView.swift; sourceTree = "<group>"; };
 		2D8F3BFDBBA72B77A16C8606 /* Services.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services.swift; sourceTree = "<group>"; };
 		2DA03A26B85DE4C884EF0CE7 /* UserSelectorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSelectorView.swift; sourceTree = "<group>"; };
+		2E3176EB2A6FF2F190D09EC5 /* SanitizeIPTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SanitizeIPTests.swift; sourceTree = "<group>"; };
 		2EFD212CB1C1A249CAD940C8 /* PhaseBlockView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhaseBlockView.swift; sourceTree = "<group>"; };
 		2F0AFD07A8CB0082733ACB36 /* SleepRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SleepRecord.swift; sourceTree = "<group>"; };
 		30D386CF79858C76A30F9B9E /* TemperatureConversion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemperatureConversion.swift; sourceTree = "<group>"; };
-		3E42AF9CF86F91B8ED2C55BD /* Sleepypod.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Sleepypod.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		3EBFFAA5F176842190082A2F /* SanitizeIPTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SanitizeIPTests.swift; sourceTree = "<group>"; };
+		3E42AF9CF86F91B8ED2C55BD /* Sleepypod.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = Sleepypod.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		43F0D2022B6D8AF6E35D4562 /* MockClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockClient.swift; sourceTree = "<group>"; };
 		452905BE65E698AC3C3419A6 /* MovementCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovementCardView.swift; sourceTree = "<group>"; };
 		489B1791FCB967E58E8D40F6 /* SensorFrames.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SensorFrames.swift; sourceTree = "<group>"; };
@@ -155,8 +156,6 @@
 		7A89CDBBC9BF2AAE10BA0302 /* SleepProfile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SleepProfile.swift; sourceTree = "<group>"; };
 		7B4A78F7220A8976E8047BF2 /* TempControlsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TempControlsView.swift; sourceTree = "<group>"; };
 		7BC90983ABD4505D2BE197D8 /* PiezoWaveformView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PiezoWaveformView.swift; sourceTree = "<group>"; };
-		BEDTEMPTV001BEDTEMPTV001 /* BedTempTrendView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BedTempTrendView.swift; sourceTree = "<group>"; };
-		RUNONCEBANNER01RUNONCE /* RunOnceActiveBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunOnceActiveBanner.swift; sourceTree = "<group>"; };
 		7E2FC5FEF1954A73556633CF /* Schedule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Schedule.swift; sourceTree = "<group>"; };
 		81EF4CCF024C14C6F5034605 /* SensorStreamService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SensorStreamService.swift; sourceTree = "<group>"; };
 		83EF454801FB06154522C928 /* StatusScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusScreen.swift; sourceTree = "<group>"; };
@@ -172,17 +171,20 @@
 		9C23ED1E696702811954A0DA /* DataPipelineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataPipelineView.swift; sourceTree = "<group>"; };
 		9E902CB9201C2AE527A6C49F /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		A0EF147CC5E285EB9FCF9DBB /* ScheduleManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduleManager.swift; sourceTree = "<group>"; };
+		A20D1974B2E3BAF1AB09CDAB /* RunOnceActiveBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunOnceActiveBanner.swift; sourceTree = "<group>"; };
 		A22017869B6697F13244EF76 /* ShareSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareSheet.swift; sourceTree = "<group>"; };
 		A42ACA637081CABD4502D011 /* APIError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIError.swift; sourceTree = "<group>"; };
 		A4464A41F150702F0C25D231 /* PiezoAnalyzer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PiezoAnalyzer.swift; sourceTree = "<group>"; };
 		A9FF9D7BA24408A31A5A650C /* DaySelectorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DaySelectorView.swift; sourceTree = "<group>"; };
 		AB34C326BB9C97E9A3E686C6 /* CalibrationSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalibrationSheet.swift; sourceTree = "<group>"; };
+		AB9D4912797C4F2688E60E8A /* BedTempTrendView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BedTempTrendView.swift; sourceTree = "<group>"; };
 		AC70CD7C5F0C026275B7EFF6 /* InternetToggleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InternetToggleTests.swift; sourceTree = "<group>"; };
 		AD6E2D8EB06314CC264F24D1 /* ServiceCategoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceCategoryView.swift; sourceTree = "<group>"; };
 		B15950D49CE8BFE7FF628BDB /* SleepStagesTimelineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SleepStagesTimelineView.swift; sourceTree = "<group>"; };
 		B31B3D5B917F4A4D5DD9E99D /* SleepypodTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = SleepypodTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B377B20C619D8127CE16AEF7 /* AICurvePromptView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AICurvePromptView.swift; sourceTree = "<group>"; };
-		B7ADF7C27937207223FDBAD9 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		B5D57FD90897EC6A2B58ABF3 /* HealthKitManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthKitManager.swift; sourceTree = "<group>"; };
+		B7ADF7C27937207223FDBAD9 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		B7C94AEB5A7EF2FE53231869 /* VitalsRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VitalsRecord.swift; sourceTree = "<group>"; };
 		B881147C7D2F0ADEBAD1AD02 /* openapi.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = openapi.json; sourceTree = "<group>"; };
 		B89A040B405BEF4117A8324F /* UserProfile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfile.swift; sourceTree = "<group>"; };
@@ -292,7 +294,7 @@
 			isa = PBXGroup;
 			children = (
 				77A6653DA02CC01836DB61EA /* BedSensorScreen.swift */,
-				BEDTEMPTV001BEDTEMPTV001 /* BedTempTrendView.swift */,
+				AB9D4912797C4F2688E60E8A /* BedTempTrendView.swift */,
 				9C23ED1E696702811954A0DA /* DataPipelineView.swift */,
 				948F9BAA88B81D25AA9E0B6F /* FirmwareLogConsoleView.swift */,
 				7BC90983ABD4505D2BE197D8 /* PiezoWaveformView.swift */,
@@ -345,8 +347,8 @@
 				DE0553DF9686966CDE7AF58B /* CalibrationTests.swift */,
 				AC70CD7C5F0C026275B7EFF6 /* InternetToggleTests.swift */,
 				1BA5BFA567D7FBA54153B602 /* MockAPIClient.swift */,
+				2E3176EB2A6FF2F190D09EC5 /* SanitizeIPTests.swift */,
 				DE5C25057170EC9CC2049440 /* SleepAnalyzerTests.swift */,
-				3EBFFAA5F176842190082A2F /* SanitizeIPTests.swift */,
 			);
 			path = SleepypodTests;
 			sourceTree = "<group>";
@@ -359,7 +361,7 @@
 				2EFD212CB1C1A249CAD940C8 /* PhaseBlockView.swift */,
 				D70A40AFFB3AAD37B22CE373 /* ProfilePickerView.swift */,
 				2B3120820F4ED5A63AAF30A6 /* RangeSlider.swift */,
-				RUNONCEBANNER01RUNONCE /* RunOnceActiveBanner.swift */,
+				A20D1974B2E3BAF1AB09CDAB /* RunOnceActiveBanner.swift */,
 				00032A1688C27E11B0BF64CC /* ScheduleScreen.swift */,
 				987F4C796A69FBEA5B834DEF /* SetPointEditor.swift */,
 				0FCC5EA8D41BF91BCCFDEA6D /* SleepTimeCardView.swift */,
@@ -374,6 +376,7 @@
 				C1C013D953D18958F2C4B435 /* AdaptiveSimulator.swift */,
 				85BD38479920F462D6470067 /* CurveGenerator.swift */,
 				2941CA088FC1C77B69F36D60 /* DeviceManager.swift */,
+				B5D57FD90897EC6A2B58ABF3 /* HealthKitManager.swift */,
 				060906F2618180E4E45E29F3 /* Log.swift */,
 				D7A651EEB721EF0EFD1B2D16 /* MetricsManager.swift */,
 				D3B44F02B272682A83840CA4 /* NotificationRelay.swift */,
@@ -432,6 +435,8 @@
 				62711B6C4B544A5E5A0FCFBE /* PBXTargetDependency */,
 			);
 			name = SleepypodTests;
+			packageProductDependencies = (
+			);
 			productName = SleepypodTests;
 			productReference = B31B3D5B917F4A4D5DD9E99D /* SleepypodTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
@@ -448,6 +453,8 @@
 			dependencies = (
 			);
 			name = Sleepypod;
+			packageProductDependencies = (
+			);
 			productName = Sleepypod;
 			productReference = 3E42AF9CF86F91B8ED2C55BD /* Sleepypod.app */;
 			productType = "com.apple.product-type.application";
@@ -477,7 +484,7 @@
 			);
 			mainGroup = 3B37E02D8C926F0693D831AD;
 			minimizedProjectReferenceProxies = 1;
-			productRefGroup = 5AB86CD34B74128771C1B77A /* Products */;
+			preferredProjectObjectVersion = 77;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
@@ -509,8 +516,8 @@
 				53581400686FE861A24087AE /* CalibrationTests.swift in Sources */,
 				BC37EEEE2AD3A4072D8141B0 /* InternetToggleTests.swift in Sources */,
 				E14081657D38C6E39C493746 /* MockAPIClient.swift in Sources */,
+				6363D9DF1E8F01CF5B5D7B88 /* SanitizeIPTests.swift in Sources */,
 				CD014B9CEE2C262CDD2637B5 /* SleepAnalyzerTests.swift in Sources */,
-				C0264F041E3EDCEB719883ED /* SanitizeIPTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -524,6 +531,7 @@
 				8DDF8FDD9FE7688543CA8831 /* APIError.swift in Sources */,
 				A3BC5A89B6475BD1E789D8B3 /* AdaptiveSimulator.swift in Sources */,
 				747C5B670447290DEE8D9218 /* BedSensorScreen.swift in Sources */,
+				89AD7DED764ACC27468103F0 /* BedTempTrendView.swift in Sources */,
 				47254DC4322FC4F3DE0DA3EC /* BetaModels.swift in Sources */,
 				DACBAF12C6747C2C8CBDE0B7 /* CalibrationSheet.swift in Sources */,
 				A58005D4A053A4021C7782D8 /* CurveGenerator.swift in Sources */,
@@ -537,6 +545,7 @@
 				E41AEAF67CA5F7801B5A13EB /* Haptics.swift in Sources */,
 				1A9A73E1A4CB9DA72F492877 /* HapticsTestView.swift in Sources */,
 				9134DC5F465DB3F287914037 /* HealthCircleView.swift in Sources */,
+				CA2789A9258049A574B585A8 /* HealthKitManager.swift in Sources */,
 				8267672B7C3A060FF4D8AB52 /* HealthMetricsGridView.swift in Sources */,
 				22F4C7CA1D9F91A639905C8B /* HealthScreen.swift in Sources */,
 				B315E300474396FF502E7D0B /* HeartRateChartView.swift in Sources */,
@@ -550,8 +559,6 @@
 				59D63C6FB621C08C2D068AA7 /* NotificationRelay.swift in Sources */,
 				F43BB4E4BD6341C7700A6480 /* PhaseBlockView.swift in Sources */,
 				874862C240D71E13B2FE3722 /* PiezoAnalyzer.swift in Sources */,
-				BEDTEMPTV002BEDTEMPTV002 /* BedTempTrendView.swift in Sources */,
-				RUNONCEBANNER02RUNONCE /* RunOnceActiveBanner.swift in Sources */,
 				0911824544AF401433A9DC43 /* PiezoWaveformView.swift in Sources */,
 				AF368CE52344A599C020EA68 /* PodDiscovery.swift in Sources */,
 				1C1212D4AE1E9773A795BCD8 /* PresenceHeatmapView.swift in Sources */,
@@ -559,6 +566,7 @@
 				A723A40EBCB30E4352F9D4B1 /* ProfilePickerView.swift in Sources */,
 				56087F2DD514F7DAFD5F4C60 /* RangeSlider.swift in Sources */,
 				783B095FE1D933AE14D94C97 /* RawDataSheet.swift in Sources */,
+				92B1607F8D33BC281B15AAAE /* RunOnceActiveBanner.swift in Sources */,
 				89CC786871A5B3B08D0EC3C4 /* Schedule.swift in Sources */,
 				4B76AE90EF4105BC911F5102 /* ScheduleManager.swift in Sources */,
 				0B484FB88EA2286B4B2B83EB /* ScheduleScreen.swift in Sources */,
@@ -624,9 +632,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = ZUR2343J7S;
 				INFOPLIST_FILE = Sleepypod/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = sleepypod;
-				INFOPLIST_KEY_NSHealthShareUsageDescription = "sleepypod reads your sleep schedule to set bedtime and wake temperatures automatically";
-				INFOPLIST_KEY_NSHealthUpdateUsageDescription = "sleepypod writes sleep session data including duration, heart rate, and sleep stages to Health";
+				INFOPLIST_KEY_NSHealthShareUsageDescription = "Sleepypod uses your sleep schedule to automatically set bedtime and wake temperatures";
 				INFOPLIST_KEY_NSLocalNetworkUsageDescription = "sleepypod connects to your sleep pod on the local network to control temperature, view sensor data, and track sleep.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = UIInterfaceOrientationPortrait;
@@ -634,7 +640,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.jonathanng.com.ios.sleepypod;
+				PRODUCT_BUNDLE_IDENTIFIER = com.jonathanng.ios.sleepypod;
 				PRODUCT_NAME = Sleepypod;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = 1;
@@ -689,7 +695,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_KEY_CFBundleDisplayName = sleepypod;
+				INFOPLIST_KEY_CFBundleDisplayName = Sleepypod;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UIUserInterfaceStyle = Dark;
 				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
@@ -714,9 +720,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = ZUR2343J7S;
 				INFOPLIST_FILE = Sleepypod/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = sleepypod;
-				INFOPLIST_KEY_NSHealthShareUsageDescription = "sleepypod reads your sleep schedule to set bedtime and wake temperatures automatically";
-				INFOPLIST_KEY_NSHealthUpdateUsageDescription = "sleepypod writes sleep session data including duration, heart rate, and sleep stages to Health";
+				INFOPLIST_KEY_NSHealthShareUsageDescription = "Sleepypod uses your sleep schedule to automatically set bedtime and wake temperatures";
 				INFOPLIST_KEY_NSLocalNetworkUsageDescription = "sleepypod connects to your sleep pod on the local network to control temperature, view sensor data, and track sleep.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = UIInterfaceOrientationPortrait;
@@ -724,7 +728,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.jonathanng.com.ios.sleepypod;
+				PRODUCT_BUNDLE_IDENTIFIER = com.jonathanng.ios.sleepypod;
 				PRODUCT_NAME = Sleepypod;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = 1;
@@ -740,7 +744,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.jonathanng.com.ios.sleepypod.tests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.jonathanng.ios.sleepypod.tests;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Sleepypod.app/Sleepypod";
@@ -801,7 +805,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_KEY_CFBundleDisplayName = sleepypod;
+				INFOPLIST_KEY_CFBundleDisplayName = Sleepypod;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UIUserInterfaceStyle = Dark;
 				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
@@ -827,7 +831,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.jonathanng.com.ios.sleepypod.tests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.jonathanng.ios.sleepypod.tests;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Sleepypod.app/Sleepypod";

--- a/Sleepypod/Services/HealthKitManager.swift
+++ b/Sleepypod/Services/HealthKitManager.swift
@@ -1,0 +1,186 @@
+import Foundation
+import HealthKit
+import Observation
+
+/// Writes Sleepypod-derived sleep + vitals to Apple Health.
+///
+/// Idempotency: every sample carries `HKMetadataKeySyncIdentifier` keyed by
+/// the source record id, so re-syncing the same week replaces prior writes
+/// instead of duplicating. The Sleepypod app is the single source for these
+/// samples in the user's Health store.
+@MainActor
+@Observable
+final class HealthKitManager {
+    var isAvailable: Bool { HKHealthStore.isHealthDataAvailable() }
+    var authorizationRequested = false
+    var lastSyncedAt: Date?
+    var lastSyncedSamples = 0
+    var error: String?
+
+    private let store = HKHealthStore()
+
+    private static let syncVersion: Int = 1
+
+    private static let writeTypes: Set<HKSampleType> = {
+        var types: Set<HKSampleType> = []
+        if let t = HKObjectType.categoryType(forIdentifier: .sleepAnalysis) { types.insert(t) }
+        if let t = HKObjectType.quantityType(forIdentifier: .heartRate) { types.insert(t) }
+        if let t = HKObjectType.quantityType(forIdentifier: .respiratoryRate) { types.insert(t) }
+        if let t = HKObjectType.quantityType(forIdentifier: .heartRateVariabilitySDNN) { types.insert(t) }
+        return types
+    }()
+
+    // MARK: - Authorization
+
+    func requestAuthorization() async {
+        guard isAvailable else {
+            Log.health.info("HealthKit unavailable on this device")
+            return
+        }
+        do {
+            try await store.requestAuthorization(toShare: Self.writeTypes, read: [])
+            authorizationRequested = true
+        } catch {
+            self.error = error.localizedDescription
+            Log.health.error("authorization failed: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    // MARK: - Sync
+
+    /// Writes sleep + vitals to Health. Safe to call repeatedly — replaces
+    /// prior samples with matching sync identifiers.
+    func sync(side: Side, sleep: [SleepRecord], vitals: [VitalsRecord]) async {
+        guard isAvailable else { return }
+
+        var samples: [HKSample] = []
+        samples.append(contentsOf: sleepSamples(records: sleep, side: side))
+        samples.append(contentsOf: vitalsSamples(records: vitals, side: side))
+
+        guard !samples.isEmpty else { return }
+
+        do {
+            try await store.save(samples)
+            lastSyncedAt = .now
+            lastSyncedSamples = samples.count
+            error = nil
+            Log.health.info("synced \(samples.count) samples (side=\(side.rawValue, privacy: .public))")
+        } catch {
+            self.error = error.localizedDescription
+            Log.health.error("save failed: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    // MARK: - Sample builders
+
+    private func sleepSamples(records: [SleepRecord], side: Side) -> [HKSample] {
+        guard let type = HKObjectType.categoryType(forIdentifier: .sleepAnalysis) else { return [] }
+        let device = sleepypodDevice(side: side)
+        var out: [HKSample] = []
+
+        for record in records {
+            let inBedStart = record.enteredBedDate
+            let inBedEnd = record.leftBedDate
+            guard inBedEnd > inBedStart else { continue }
+
+            // In-bed interval — covers the full session window
+            out.append(HKCategorySample(
+                type: type,
+                value: HKCategoryValueSleepAnalysis.inBed.rawValue,
+                start: inBedStart,
+                end: inBedEnd,
+                device: device,
+                metadata: metadata(syncId: "sleepypod-inbed-\(side.rawValue)-\(record.id)", side: side)
+            ))
+
+            // Asleep interval — duration from sleepPeriodSeconds, anchored to bed entry.
+            // We don't have stage-level breakdown, so emit asleepUnspecified.
+            let asleepSeconds = TimeInterval(record.sleepPeriodSeconds)
+            if asleepSeconds > 0 {
+                let asleepEnd = min(inBedStart.addingTimeInterval(asleepSeconds), inBedEnd)
+                out.append(HKCategorySample(
+                    type: type,
+                    value: HKCategoryValueSleepAnalysis.asleepUnspecified.rawValue,
+                    start: inBedStart,
+                    end: asleepEnd,
+                    device: device,
+                    metadata: metadata(syncId: "sleepypod-asleep-\(side.rawValue)-\(record.id)", side: side)
+                ))
+            }
+        }
+        return out
+    }
+
+    private func vitalsSamples(records: [VitalsRecord], side: Side) -> [HKSample] {
+        let bpm = HKUnit(from: "count/min")
+        let ms = HKUnit.secondUnit(with: .milli)
+        let device = sleepypodDevice(side: side)
+        var out: [HKSample] = []
+
+        for record in records {
+            let date = record.date
+            guard date.timeIntervalSince1970 > 0 else { continue }
+
+            if let hr = record.heartRate, hr > 0,
+               let type = HKObjectType.quantityType(forIdentifier: .heartRate) {
+                out.append(HKQuantitySample(
+                    type: type,
+                    quantity: HKQuantity(unit: bpm, doubleValue: hr),
+                    start: date,
+                    end: date,
+                    device: device,
+                    metadata: metadata(syncId: "sleepypod-hr-\(side.rawValue)-\(record.id)", side: side)
+                ))
+            }
+
+            if let br = record.breathingRate, br > 0,
+               let type = HKObjectType.quantityType(forIdentifier: .respiratoryRate) {
+                out.append(HKQuantitySample(
+                    type: type,
+                    quantity: HKQuantity(unit: bpm, doubleValue: br),
+                    start: date,
+                    end: date,
+                    device: device,
+                    metadata: metadata(syncId: "sleepypod-br-\(side.rawValue)-\(record.id)", side: side)
+                ))
+            }
+
+            if let hrv = record.hrv, hrv > 0,
+               let type = HKObjectType.quantityType(forIdentifier: .heartRateVariabilitySDNN) {
+                out.append(HKQuantitySample(
+                    type: type,
+                    quantity: HKQuantity(unit: ms, doubleValue: hrv),
+                    start: date,
+                    end: date,
+                    device: device,
+                    metadata: metadata(syncId: "sleepypod-hrv-\(side.rawValue)-\(record.id)", side: side)
+                ))
+            }
+        }
+        return out
+    }
+
+    // MARK: - Helpers
+
+    private func metadata(syncId: String, side: Side) -> [String: Any] {
+        [
+            HKMetadataKeySyncIdentifier: syncId,
+            HKMetadataKeySyncVersion: Self.syncVersion,
+            HKMetadataKeyExternalUUID: syncId,
+            "sleepypod_side": side.rawValue,
+        ]
+    }
+
+    private func sleepypodDevice(side: Side) -> HKDevice {
+        HKDevice(
+            name: "Sleepypod",
+            manufacturer: "Sleepypod",
+            model: "Pod",
+            hardwareVersion: nil,
+            firmwareVersion: nil,
+            softwareVersion: nil,
+            localIdentifier: side.rawValue,
+            udiDeviceIdentifier: nil
+        )
+    }
+}

--- a/Sleepypod/Services/Log.swift
+++ b/Sleepypod/Services/Log.swift
@@ -9,4 +9,5 @@ enum Log {
     static let device = Logger(subsystem: "com.jonathanng.ios.sleepypod", category: "device")
     static let general = Logger(subsystem: "com.jonathanng.ios.sleepypod", category: "general")
     static let sensor = Logger(subsystem: "com.jonathanng.ios.sleepypod", category: "sensor")
+    static let health = Logger(subsystem: "com.jonathanng.ios.sleepypod", category: "health")
 }

--- a/Sleepypod/Sleepypod.entitlements
+++ b/Sleepypod/Sleepypod.entitlements
@@ -4,9 +4,5 @@
 <dict>
 	<key>com.apple.developer.healthkit</key>
 	<true/>
-	<key>com.apple.developer.healthkit.access</key>
-	<array>
-		<string>health-records</string>
-	</array>
 </dict>
 </plist>

--- a/Sleepypod/SleepypodApp.swift
+++ b/Sleepypod/SleepypodApp.swift
@@ -12,6 +12,7 @@ struct SleepypodApp: App {
     @State private var userProfile = UserProfile()
     @State private var sensorStream = SensorStreamService()
     @State private var notificationRelay = NotificationRelay()
+    @State private var healthKit = HealthKitManager()
 
     init() {
         let client = APIBackend.current.createClient()
@@ -41,10 +42,12 @@ struct SleepypodApp: App {
                 .environment(userProfile)
                 .environment(sensorStream)
                 .environment(notificationRelay)
+                .environment(healthKit)
                 .preferredColorScheme(.dark)
                 .task {
                     await notificationRelay.requestPermission()
                     sensorStream.notificationRelay = notificationRelay
+                    await healthKit.requestAuthorization()
                 }
         }
     }

--- a/Sleepypod/Views/Data/HealthScreen.swift
+++ b/Sleepypod/Views/Data/HealthScreen.swift
@@ -4,6 +4,7 @@ import Charts
 struct HealthScreen: View {
     @Environment(MetricsManager.self) private var metricsManager
     @Environment(SettingsManager.self) private var settingsManager
+    @Environment(HealthKitManager.self) private var healthKit
 
     @State private var showRawData = false
     @State private var sleepAnalyzer = SleepAnalyzer()
@@ -365,6 +366,12 @@ struct HealthScreen: View {
             vitals: metricsManager.vitalsRecords,
             movement: metricsManager.movementRecords,
             calibrationQuality: status?.piezo?.qualityScore ?? 0.0
+        )
+
+        await healthKit.sync(
+            side: metricsManager.selectedSide,
+            sleep: metricsManager.sleepRecords,
+            vitals: metricsManager.vitalsRecords
         )
     }
 

--- a/project.yml
+++ b/project.yml
@@ -29,8 +29,6 @@ targets:
       path: Sleepypod/Sleepypod.entitlements
       properties:
         com.apple.developer.healthkit: true
-        com.apple.developer.healthkit.access:
-          - health-records
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.jonathanng.ios.sleepypod


### PR DESCRIPTION
## Summary

- New `HealthKitManager` service writes Sleepypod's already-parsed sleep + vitals records into Apple Health on every Biometrics-tab refresh.
- Idempotent: every sample carries `HKMetadataKeySyncIdentifier` so repeated syncs of the same week replace prior writes instead of duplicating.
- Drops `health-records` from the entitlements file (that key is for clinical FHIR records and would trigger extra App Store review for nothing).

## What gets written

| Source | HealthKit type | Notes |
|---|---|---|
| `SleepRecord.enteredBedDate..leftBedDate` | `.sleepAnalysis` (`inBed`) | full bed window |
| `SleepRecord.sleepPeriodSeconds` | `.sleepAnalysis` (`asleepUnspecified`) | duration anchored at bed entry; we don't have stage-level data |
| `VitalsRecord.heartRate` | `.heartRate` (count/min) | point sample |
| `VitalsRecord.breathingRate` | `.respiratoryRate` (count/min) | point sample |
| `VitalsRecord.hrv` | `.heartRateVariabilitySDNN` (ms) | point sample |

All samples attributed to an `HKDevice` named `Sleepypod` so Health surfaces the source clearly.

## Test plan

- [ ] Install on a real device (HealthKit unavailable on simulator for write paths).
- [ ] First launch: confirm Health permission sheet appears for sleepAnalysis, heartRate, respiratoryRate, heartRateVariabilitySDNN.
- [ ] Open Biometrics tab, pull-to-refresh; confirm Health → Sleep / Heart / Respiratory / HRV show samples sourced "Sleepypod".
- [ ] Refresh again; confirm sample count in Health stays the same (idempotency).
- [ ] Toggle side; confirm samples for the other side appear without overwriting the first side's data (sync ids include side).

## Follow-ups (not in this PR)

- RAW pod file → on-device parse (would feed the same sync surface).
- Stage-level sleep (`.asleepCore` / `.asleepDeep` / `.asleepREM`) once `SleepAnalyzer` exposes per-interval stages.
- Background sync via APNs silent push when a session ends, so users don't have to open the tab.