### PR TITLE
ci: use Codecov OIDC instead of token

### DIFF
--- a/.github/workflows/contract-test.yml
+++ b/.github/workflows/contract-test.yml
@@ -11,6 +11,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   build:

--- a/.github/workflows/contract-test.yml
+++ b/.github/workflows/contract-test.yml
@@ -124,7 +124,7 @@ jobs:
         if: always()
         uses: codecov/codecov-action@v5
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          use_oidc: true
           slug: sleepypod/ios
           files: contract-tests/lcov.info
           flags: contract-tests
@@ -133,7 +133,8 @@ jobs:
         if: ${{ !cancelled() }}
         uses: codecov/test-results-action@v1
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          use_oidc: true
+          slug: sleepypod/ios
           files: contract-tests/test-results.xml
 
       - name: Stop server


### PR DESCRIPTION
## Summary
- Replace `token: \${{ secrets.CODECOV_TOKEN }}` with `use_oidc: true` on both Codecov uploads (coverage + test results). The Codecov GitHub App is installed, so OIDC removes the token-mismatch failure mode and we no longer need to maintain `CODECOV_TOKEN`.
- Add explicit `slug: sleepypod/ios` to the test-results upload for parity with the coverage step.

## Test plan
- [ ] Workflow run on this PR uploads coverage to Codecov successfully via OIDC
- [ ] Workflow run uploads test results to Codecov successfully via OIDC
- [ ] Codecov badge in README continues to render after merge to dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)