### PR TITLE
docs: add badge row matching sleepypod-core

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,14 @@
-# Sleepypod iOS
+# sleepypod iOS
 
+[![CI](https://github.com/sleepypod/ios/actions/workflows/contract-test.yml/badge.svg?branch=dev)](https://github.com/sleepypod/ios/actions/workflows/contract-test.yml)
 [![codecov](https://codecov.io/gh/sleepypod/ios/branch/dev/graph/badge.svg)](https://codecov.io/gh/sleepypod/ios)
+[![Release](https://img.shields.io/github/v/release/sleepypod/ios?sort=semver)](https://github.com/sleepypod/ios/releases/latest)
+[![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](LICENSE)
+[![Platform](https://img.shields.io/badge/platform-iOS%2026%2B-lightgrey.svg)](#requirements)
+[![Swift](https://img.shields.io/badge/swift-6.0-orange.svg)](#requirements)
+[![Discord](https://img.shields.io/discord/1450213183653679205?logo=discord&logoColor=white&label=discord)](https://discord.gg/UMmv5R6MXa)
 
-Native iOS app for controlling and monitoring your [Sleepypod](https://github.com/sleepypod/core) — temperature control, sleep tracking, biometrics, and on-device analysis.
+Native iOS app for controlling and monitoring your [sleepypod](https://github.com/sleepypod/core) — temperature control, sleep tracking, biometrics, and on-device analysis.
 
 <p align="center">
   <img src="docs/images/temperature-control.png" width="280" alt="Temperature control" />
@@ -94,7 +100,7 @@ Any backend conforms to `SleepypodProtocol` and the entire app works — no view
 - iOS 26.0+
 - Xcode 26+
 - Swift 6.0
-- A Sleepypod on the local network
+- A sleepypod on the local network
 
 ## Setup
 


### PR DESCRIPTION
## Summary
- Add CI, Release, License (AGPL v3), Platform (iOS 26+), Swift 6, and Discord badges alongside the existing codecov one — mirrors the sleepypod-core README header.
- Lowercase **Sleepypod** → **sleepypod** in prose only (title, intro, requirements). Code identifiers (\`SleepypodProtocol\`, \`Sleepypod.xcodeproj\`, scheme \`Sleepypod\`) are unchanged because they're real symbols/paths.

## Test plan
- [ ] All seven badges render on GitHub
- [ ] CI badge points at \`contract-test.yml\` and shows passing status on \`dev\`
- [ ] Release badge picks up \`v1.2.2\`
- [ ] Discord badge links to the same invite as core

🤖 Generated with [Claude Code](https://claude.com/claude-code)